### PR TITLE
Fixed issues with CORS on websocket gateway

### DIFF
--- a/src/websocket/gateway.websocket.ts
+++ b/src/websocket/gateway.websocket.ts
@@ -1,6 +1,6 @@
 import {Logger} from '@nestjs/common';
 import {
-    ConnectedSocket,
+    ConnectedSocket, GatewayMetadata,
     MessageBody,
     OnGatewayConnection,
     OnGatewayInit,
@@ -13,12 +13,14 @@ import {Server, Socket} from 'socket.io';
 
 import {NotificationChannels} from '@app/utils';
 
-@WebSocketGateway({
+@WebSocketGateway<GatewayMetadata>({
+    allowEIO3: true,
     serveClient: false,
     cors: {
         preflightContinue: true,
-        origin: '*'
-    }
+        credentials: true,
+        origin: ['https://explorer.testnet.lum.network', 'https://explorer.lum.network', 'http://localhost:3001']
+    },
 })
 export class GatewayWebsocket implements OnGatewayInit, OnGatewayConnection {
     private _logger: Logger = new Logger(GatewayWebsocket.name);


### PR DESCRIPTION
This PR introduces a fix for the websocket gateway, that had CORS problems.

Are now allowed 3 origins: both mainnet & testnet explorers, and the local development server for explorer on port 3001.