### PR TITLE
[LUM-297] Fix failed tx addresses parsing

### DIFF
--- a/src/async/consumers/block.consumer.ts
+++ b/src/async/consumers/block.consumer.ts
@@ -105,6 +105,17 @@ export class BlockConsumer {
                     raw_tx_data: LumUtils.toJSON(txData) as string,
                 };
 
+                // Add addresses in case of transaction failure
+                if (!res.success) {
+                    for (const message of res.messages) {
+                        for (const key in message.value) {
+                            if (key === 'sender' || key === 'recipient' || key === 'validator') {
+                                res.addresses.push(message.value[key]);
+                            }
+                        }
+                    }
+                }
+
                 for (const log of logs) {
                     for (const ev of log.events) {
                         for (const attr of ev.attributes) {

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -25,7 +25,7 @@ export class TransactionService {
     };
 
     fetchForAddress = async (address: string, skip: number, take: number): Promise<[TransactionEntity[], number]> => {
-        const query = this._repository.createQueryBuilder('transactions').where(':batch = ANY(transactions.addresses)', {batch: address}).skip(skip).take(take);
+        const query = this._repository.createQueryBuilder('transactions').where(':batch = ANY(transactions.addresses)', {batch: address}).orderBy('transactions.time', 'DESC').skip(skip).take(take);
         return query.getManyAndCount();
     }
 


### PR DESCRIPTION
This PR fix two things related to transactions:
- The method `fetchForAddress` in `transactionService` returns now the transactions in correct order
- The addresses array is now set In case of transaction failure