### PR TITLE
fix: error tvl, apy, metrics

### DIFF
--- a/src/async/schedulers/asset.scheduler.ts
+++ b/src/async/schedulers/asset.scheduler.ts
@@ -16,8 +16,8 @@ export class AssetScheduler {
         private readonly _chainService: ChainService,
     ) {}
 
-    @Cron(CronExpression.EVERY_HOUR)
-    async syncHourly(): Promise<void> {
+    @Cron(CronExpression.EVERY_5_MINUTES)
+    async syncValue(): Promise<void> {
         try {
             this._logger.log(`Syncing latest assets info from chain...`);
             // We sync all values except DFR every hour by starting with LUM
@@ -39,7 +39,7 @@ export class AssetScheduler {
     }
 
     @Cron(CronExpression.EVERY_WEEK)
-    async syncWeekly(): Promise<void> {
+    async syncExtraWeekly(): Promise<void> {
         try {
             // We only update chain values other than DFR once a week
 

--- a/src/services/asset.service.ts
+++ b/src/services/asset.service.ts
@@ -126,4 +126,26 @@ export class AssetService {
 
         return query;
     };
+
+    getChainServiceApy = async (): Promise<any> => {
+        const query = await this._repository.createQueryBuilder('assets').select(['id', 'value']).where('id like :id', { id: `%apy%` }).getRawMany();
+
+        const filteredQuery = query.filter((el) => el.id !== 'dfr_apy' && el.id !== 'lum_apy');
+
+        return filteredQuery.map((el) => ({
+            symbol: el.id.substring(0, el.id.indexOf('_')).toUpperCase(),
+            apy: el?.value.apy,
+        }));
+    };
+
+    getChainServicePrice = async (): Promise<any> => {
+        const query = await this._repository.createQueryBuilder('assets').select(['id', 'value']).where('id like :id', { id: `%unit_price_usd%` }).getRawMany();
+
+        const filteredQuery = query.filter((el) => el.id !== 'dfr_unit_price_usd' && el.id !== 'lum_unit_price_usd');
+
+        return filteredQuery.map((el) => ({
+            symbol: el.id.substring(0, el.id.indexOf('_')).toUpperCase(),
+            unit_price_usd: el?.value.unit_price_usd,
+        }));
+    };
 }


### PR DESCRIPTION
**Errors origin**

Metrics scheduler calling -> dfr service -> calling chain service -> making third party api calls -> receiving 502 and typeror: fetched failed.
This caused a chain of metrics errors, tvl null and apy null.

**Solution**
- Query in the DB for price and apy instead of making third party calls every min.
- The asset scheduler will be updated every 5min to keep the metrics in sync and coherent data

**Remaining Issue**
502 when the getTvl method in chain sercice get triggered too much. We loop through the clients that are connected to rpc emperator.

Screenshot attached

![Screenshot 2022-11-18 at 20 39 01](https://user-images.githubusercontent.com/14543287/202800322-741a43cc-46bc-4def-983b-2972c5bfaca7.png)
