### PR TITLE
[LUM-748] Sync draws via event

### DIFF
--- a/src/async/consumers/block.consumer.ts
+++ b/src/async/consumers/block.consumer.ts
@@ -5,10 +5,10 @@ import { Job, Queue } from 'bull';
 import dayjs from 'dayjs';
 import { LumConstants, LumMessages, LumRegistry, LumUtils } from '@lum-network/sdk-javascript';
 
-import { AssetSymbol, getAddressesRelatedToTransaction, isBeam, NotificationChannels, NotificationEvents, QueueJobs, QueuePriority, Queues } from '@app/utils';
-
-import { BlockService, ChainService, TransactionService, ValidatorService } from '@app/services';
+import { MillionsScheduler } from '@app/async';
 import { BlockEntity, TransactionEntity } from '@app/database';
+import { BlockService, ChainService, TransactionService, ValidatorService } from '@app/services';
+import { AssetSymbol, getAddressesRelatedToTransaction, isBeam, NotificationChannels, NotificationEvents, QueueJobs, QueuePriority, Queues } from '@app/utils';
 
 @Processor(Queues.BLOCKS)
 export class BlockConsumer {
@@ -23,6 +23,7 @@ export class BlockConsumer {
         private readonly _chainService: ChainService,
         private readonly _transactionService: TransactionService,
         private readonly _validatorService: ValidatorService,
+        private readonly _millionsScheduler: MillionsScheduler,
     ) {}
 
     @Process(QueueJobs.INGEST)
@@ -169,6 +170,11 @@ export class BlockConsumer {
                                     },
                                 );
                             }
+                        }
+
+                        // Sync Millions Draw
+                        if (ev.type === 'draw_success') {
+                            this._millionsScheduler.drawsSync().finally(() => null);
                         }
                     }
                 }

--- a/src/async/consumers/block.consumer.ts
+++ b/src/async/consumers/block.consumer.ts
@@ -21,9 +21,9 @@ export class BlockConsumer {
         @InjectQueue(Queues.NOTIFICATIONS) private readonly _notificationQueue: Queue,
         private readonly _blockService: BlockService,
         private readonly _chainService: ChainService,
+        private readonly _millionsScheduler: MillionsScheduler,
         private readonly _transactionService: TransactionService,
         private readonly _validatorService: ValidatorService,
-        private readonly _millionsScheduler: MillionsScheduler,
     ) {}
 
     @Process(QueueJobs.INGEST)


### PR DESCRIPTION
The draws are already synchronized every ten minutes, but we want to synchronize them after each draw.
Currently, the synchronization occurs after the draw_success event.