### PR TITLE
[LUM-895] Fix draws and prizes sync

### DIFF
--- a/src/async/schedulers/millions.scheduler.ts
+++ b/src/async/schedulers/millions.scheduler.ts
@@ -173,7 +173,8 @@ export class MillionsScheduler {
                         updated_at_height: Number(draw.updatedAtHeight),
                         created_at: draw.createdAt,
                         updated_at: draw.updatedAt,
-                        usd_token_value: await this._marketService.getTokenPrice(getAssetSymbol(pool.denom_native)),
+                        // We don't use this value anymore
+                        usd_token_value: 0,
                     };
 
                     // If draw doesn't exist in db, we save it
@@ -205,7 +206,8 @@ export class MillionsScheduler {
                                 expires_at: dayjs(draw.createdAt).add(Number(prizeExpirationDelta.seconds), 'seconds').toDate(),
                                 created_at: draw.createdAt,
                                 updated_at: draw.updatedAt,
-                                usd_token_value: savedDraw ? savedDraw.usd_token_value : formattedDraw.usd_token_value,
+                                // We don't use this value anymore
+                                usd_token_value: 0,
                             };
 
                             await this._millionsPrizeService.createOrUpdate(formattedPrize);

--- a/src/sync_consumer.ts
+++ b/src/sync_consumer.ts
@@ -2,7 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { RedisOptions, Transport } from '@nestjs/microservices';
 
 import * as parseRedisUrl from 'parse-redis-url-simple';
-import { Logger } from 'nestjs-pino';
 
 import { SyncConsumerModule } from '@app/modules';
 
@@ -23,7 +22,6 @@ async function bootstrap() {
         },
     });
 
-    // app.useLogger(app.get(Logger));
     await app.listen();
 }
 

--- a/src/sync_scheduler.ts
+++ b/src/sync_scheduler.ts
@@ -2,7 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { RedisOptions, Transport } from '@nestjs/microservices';
 
 import * as parseRedisUrl from 'parse-redis-url-simple';
-import { Logger } from 'nestjs-pino';
 
 import { SyncSchedulerModule } from '@app/modules';
 
@@ -23,7 +22,6 @@ async function bootstrap() {
         },
     });
 
-    // app.useLogger(app.get(Logger));
     await app.listen();
 }
 


### PR DESCRIPTION
####Introduction

This PR set `usd_token_value` to 0 to prevent a bug during market value retrieval.

####Testing

Verify that all draws are synchronized on this endpoint: GET "/millions/draws?limit=100".